### PR TITLE
fix: pin GitHub Actions to full SHA (CLOUDEVOPS-4942)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.1.0
+        uses: golangci/golangci-lint-action@b517f99ae23d86ecc4c0dec08dcf48d2336abc29 # v3.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.45

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24"
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
           args: release --clean

--- a/.github/workflows/sourceguard.yml
+++ b/.github/workflows/sourceguard.yml
@@ -9,7 +9,7 @@ jobs:
       image: sourceguard/sourceguard-cli
     steps:
       - name: Scan
-        uses: CheckPointSW/sourceguard-action@main
+        uses: CheckPointSW/sourceguard-action@ddeadaa391a6defb21ef4228b91956b062c27862 # main
         with:
           SG_CLIENT_ID: ${{ secrets.SG_CLIENT_ID }}
           SG_SECRET_KEY: ${{ secrets.SG_SECRET_KEY }}


### PR DESCRIPTION
## External Actions (pinned to SHA)

**CheckPointSW**

- `CheckPointSW/sourceguard-action@main` → `ddeadaa` · [verify](https://github.com/CheckPointSW/sourceguard-action/commit/ddeadaa391a6defb21ef4228b91956b062c27862)

**actions**

- `actions/checkout@v4` → `34e1148` · [verify](https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5)
- `actions/setup-go@v5` → `40f1582` · [verify](https://github.com/actions/setup-go/commit/40f1582b2485089dde7abd97c1529aa768e1baff)

**golangci**

- `golangci/golangci-lint-action@v3.1.0` → `b517f99` · [verify](https://github.com/golangci/golangci-lint-action/commit/b517f99ae23d86ecc4c0dec08dcf48d2336abc29)

**goreleaser**

- `goreleaser/goreleaser-action@v6` → `e435ccd` · [verify](https://github.com/goreleaser/goreleaser-action/commit/e435ccd777264be153ace6237001ef4d979d3a7a)